### PR TITLE
Fix: render/index.js에서 module.exports = router 누락

### DIFF
--- a/src/render/index.js
+++ b/src/render/index.js
@@ -2,3 +2,5 @@
 
 const express = require('express');
 const router = express.Router();
+
+module.exports = router


### PR DESCRIPTION
PR #6에서 누락됨

## 개요
- 코드 리뷰에서 src/render/index.js의 module.exports = router가 누락된 걸 깜빡함.
- 서버를 돌려봤을 때 에러가 났음.

## 작업사항
- src/render/index.js에 module.exports = router 추가.
