### PR TITLE
해당하는 라우터가 없을 때 404 에러 핸들러와 에러가 났을 때 오류 처리기 핸들러 추가

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,13 @@ app.use("/", (req, res, next) => {
   res.status(404).send("Not Found");
 });
 
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  res.status(err.statusCode || 500).json({
+    errorMessage: err.message || "Internal Error",
+  });
+});
+
 sequelize
   .sync({ force: false })
   .then(() => {

--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,10 @@ app.set("views", path.join(__dirname, "../views"));
 
 app.use(express.static(path.join(__dirname, "../public"))); //정적파일, 이미지파일
 
+app.use("/", (req, res, next) => {
+  res.status(404).send("Not Found");
+});
+
 sequelize
   .sync({ force: false })
   .then(() => {


### PR DESCRIPTION
## 개요
- 어떠한 라우팅도 hit하지 않을 때, 404 에러 응답하도록 함
- 에러가 발생했을 때 에러를 응답하도록 만듬.

## 작업사항
- 404 핸들러, 에러 핸들러 추가. (app.js)